### PR TITLE
Update ShareDirBuilder.pm

### DIFF
--- a/lib/DBIx/Class/Migration/ShareDirBuilder.pm
+++ b/lib/DBIx/Class/Migration/ShareDirBuilder.pm
@@ -30,7 +30,7 @@ sub build {
     last unless $class =~s/::[^\:\:]+$//;
   }
 
-  return $sharedir || die "Can't find a /share for $class";
+  return $sharedir || die "Can't find a share ($sharedir) for $class";
 
 }
 


### PR DESCRIPTION
Included actual share path into the error message. Otherwise it makes the message sound as if it is actually looking for directory named "/share".
