### PR TITLE
Permission denied error running dbic-migration with no target dir specified

### DIFF
--- a/lib/DBIx/Class/Migration/Script.pm
+++ b/lib/DBIx/Class/Migration/Script.pm
@@ -123,7 +123,7 @@ has migration => (
     my $self = shift;
     return (
       ($self->has_force_overwrite ? (force_overwrite => $self->force_overwrite) : ()),
-      ($self->has_target_dir ? (script_directory=>$self->target_dir) : ()),
+      ($self->has_target_dir && $self->target_dir ? (script_directory=>$self->target_dir) : ()),
       ($self->has_to_version ? (to_version=>$self->to_version) : ()),
       ($self->has_databases ? (databases=>$self->databases) : ()),
     );

--- a/t/script.t
+++ b/t/script.t
@@ -1,0 +1,31 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use lib 't/lib';
+
+use Test::Most;
+use DBIx::Class::Migration::Script;
+
+use File::Spec::Functions 'catfile';
+use File::Path 'rmtree';
+use Local::Schema;
+
+## Create an in-memory sqlite version of the test schema
+(my $schema = Local::Schema->connect('dbi:SQLite::memory:'))
+  ->deploy;
+
+## Connect a DBIC migration to that
+my $script = DBIx::Class::Migration::Script->new_with_options( schema => $schema );
+
+## Install the version storage and set the version
+lives_ok { $script->cmd_prepare() };
+
+done_testing;
+
+END {
+  rmtree catfile($script->migration->target_dir, 'migrations');
+  rmtree catfile($script->migration->target_dir, 'fixtures');
+  unlink catfile($script->migration->target_dir, 'local-schema.db');
+}


### PR DESCRIPTION
Hi John, I was following the tutorial and hit an error running prepare without a target dir specified:

```
$ dbic-migration --schema_class Bean::AdcDB::Schema -Ilib prepare
mkdir /_source: Permission denied at .../lib/perl5/Path/Class/Dir.pm line 154.
```

Supplying a target_dir (`--target_dir share`) works as intended.

DBIC::Mig::Script passes an empty `script_directory` in the deployment handler opts so DH tries to install to `/` instead of the default `share`.

This happens because all predicate methods on attributes with the MooseX::Attributes::ENV trait return true. This is because MooseX::Attributes::ENV using defaults so the attribute value will be set afterwards (I can't see any way for a default sub to bail and return a 'not set' value)

``` perl
# has_* always returns true even though it hasn't been set
DBIx::Class::Migration::Script->new_with_options->has_target_dir();
```

I ran all the tests after the change and they still pass.
