### PR TITLE
Changing dist.ini to build with t/.devdir

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -6,7 +6,9 @@ copyright_year = 2013
 abstract = Tools to make migrating your DBIx::Class databases easier
 version = 0.042
 
-[@Basic]
+[@ConfigSlicer]
+-bundle = @Basic
+GatherDir.include_dotfiles = 1
 
 [MetaResources]
 homepage = https://github.com/jjn1056/DBIx-Class-Migration


### PR DESCRIPTION
A possible solution to not losing t/.devdir during dzil build.
