### PR TITLE
Fix bug where script_directory is being overwritten by %dbic_dh_args

### DIFF
--- a/lib/DBIx/Class/Migration.pm
+++ b/lib/DBIx/Class/Migration.pm
@@ -175,8 +175,8 @@ sub dbic_dh {
 
   my $dh = $self->deployment_handler_class->new({
     schema => $self->schema,
-    script_directory => catdir($self->target_dir, 'migrations'),
     %dbic_dh_args, @args,
+    script_directory => catdir($self->target_dir, 'migrations'),
   });
 
   return $dh;


### PR DESCRIPTION
script_directory is getting overwritten by contents of %dbic_dh_args when using --target_dir options.

Before this change when using --target_dir my output dir would look like this:
  ls share/
  fixtures  MySQL  _source

This is because the dbic_dh_args hash gets a key named script_directory:

print Dumper \%dbic_dh_args;

$VAR1 = {
          'databases' => [
                           'MySQL'
                         ],
          'script_directory' => '/asc/array1/Projects/dists/Apace-Schema-ACL/share'
        };

so the the script_directory key is instantly overwritten and the migrations dir is never concatenated.
