### PR TITLE
Call `remove_tree` as function

### DIFF
--- a/lib/DBIx/Class/Migration.pm
+++ b/lib/DBIx/Class/Migration.pm
@@ -447,7 +447,7 @@ sub delete_named_sets {
     my ($self, $path) = @_;
     return unless -d $path;
     print "Deleting $path \n";
-    $path->rmtree;
+    remove_tree($path);
   }
 
 


### PR DESCRIPTION
Can't call `rmtree` as method; `$path` is a scalar (string) not a Path object.

Signed-off-by: Charlie Garrison <cngarrison@gmail.com>