### PR TITLE
Quote table names when dropping them

### DIFF
--- a/lib/DBIx/Class/Migration.pm
+++ b/lib/DBIx/Class/Migration.pm
@@ -334,10 +334,11 @@ sub drop_tables {
     foreach my $source ($schema->sources) {
       my $table = $schema->source($source)->name;
       print "Dropping table $table\n";
+      my $tableq = $schema->storage->dbh->quote_identifier($table);
       if(ref($schema->storage) =~m/Pg$/) {
-        $schema->storage->dbh->do("drop table $table CASCADE");
+        $schema->storage->dbh->do("drop table $tableq CASCADE");
       } else {
-        $schema->storage->dbh->do("drop table $table");
+        $schema->storage->dbh->do("drop table $tableq");
       }
     }
   });


### PR DESCRIPTION
This patch quotes table names before attempting to drop them. This allows table names such as "group" to be used. This is hard-coded as enabled: I can't think of a reason why you wouldn't want this, but let me know if you would prefer it as a configurable option.

Thanks,

Andy
