### PR TITLE
Fix the hashbang line

### DIFF
--- a/bin/dbic-migration
+++ b/bin/dbic-migration
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!perl
 
 (require DBIx::Class::Migration::Script)
   ->run_with_options;


### PR DESCRIPTION
Currently, ExtUtils::MakeMaker rewrites "#!perl" to the full path of the
perl binary used for installation.  It does not rewrite "#!/usr/bin/env perl"
which means that this script tries to run against the perl in your path,
not necessarily the perl used to install this script.