### PR TITLE
Add TODO blocks for MySQL tests which fail for Perl >= 5.18 GH issue #59

### DIFF
--- a/t/migration-mysql.t
+++ b/t/migration-mysql.t
@@ -52,7 +52,10 @@ use DBIx::Class::Migration::RunScript;
 migrate {
   my $self = shift;
   if($self->set_has_fixtures('all_tables')) {
-    $self->populate('all_tables');
+    TODO: {
+      local $TODO = 'Perl >= 5.18 stringifies %ENV values' if $] ge '5.018';
+      lives_ok { $self->populate('all_tables') } "->populate('all_tables')";
+    }
   } else {
     $self->schema
       ->resultset('Country')
@@ -63,9 +66,12 @@ migrate {
         ['fra'],
       ]);
 
-    $self->dump('all_tables');
-    ok $self->set_has_fixtures('all_tables'),
-      'Fixture Set exists!';
+    TODO: {
+      local $TODO = 'Perl >= 5.18 stringifies %ENV values' if $] ge '5.018';
+      lives_ok { $self->dump('all_tables') } "->dump('all_tables')";
+      ok $self->set_has_fixtures('all_tables'),
+        'Fixture Set exists!';
+    }
   }
 
 };
@@ -78,8 +84,11 @@ $migration->install;
 ok $schema->resultset('Country')->find({code=>'fra'}),
   'got some previously inserted data';
 
-ok -e catfile($target_dir, 'fixtures','1','all_tables','country','1.fix'),
-  'found a fixture from runscript dump';
+TODO: {
+  local $TODO = 'Perl >= 5.18 stringifies %ENV values' if $] ge '5.018';
+  ok -e catfile($target_dir, 'fixtures','1','all_tables','country','1.fix'),
+    'found a fixture from runscript dump';
+}
 
 rmtree catfile($target_dir, 'fixtures','1','all_tables');
 
@@ -116,8 +125,11 @@ NEW_SCOPE_FOR_SCHEMA: {
 
   $migration->install;
 
-  ok $schema->resultset('Country')->find({code=>'fra'}),
-    'got some previously inserted data';
+  TODO: {
+    local $TODO = 'Perl >= 5.18 stringifies %ENV values' if $] ge '5.018';
+    ok $schema->resultset('Country')->find({code=>'fra'}),
+      'got some previously inserted data';
+  }
 
   $migration->delete_table_rows;
   $migration->populate('all_tables');


### PR DESCRIPTION
As from v5.18.0 Perl stringifies %ENV values which causes problems for
Dump and Populate traits which are passed a Fixtures object via %ENV.
The Fixtures object gets stringified and so these traits cannot work for
recent Perls. For now add TODO blocks to tag this issue within the
tests.