### PR TITLE
pass fixtures obj init args and class instead of obj in ENV closes #59

### DIFF
--- a/lib/DBIx/Class/Migration/RunScript/Trait/Dump.pm
+++ b/lib/DBIx/Class/Migration/RunScript/Trait/Dump.pm
@@ -3,12 +3,19 @@ package DBIx::Class::Migration::RunScript::Trait::Dump;
 use Moose::Role;
 use File::Spec::Functions 'catdir', 'catfile';
 use File::Path 'mkpath';
+use JSON::XS;
 
 requires 'schema';
 
 sub dump {
   my ($self, @sets) = @_;
-  $ENV{DBIC_MIGRATION_FIXTURES_OBJ}->dump_config_sets({
+
+  my $fixtures_init_args =
+    JSON::XS->new->decode( $ENV{DBIC_MIGRATION_FIXTURES_INIT_ARGS} );
+  my $fixtures_obj =
+    $ENV{DBIC_MIGRATION_FIXTURES_CLASS}->new($fixtures_init_args);
+
+  $fixtures_obj->dump_config_sets({
     schema => $self->schema,
     configs => [map { "$_.json" } @sets],
     directory_template => sub {

--- a/lib/DBIx/Class/Migration/RunScript/Trait/Populate.pm
+++ b/lib/DBIx/Class/Migration/RunScript/Trait/Populate.pm
@@ -2,13 +2,20 @@ package DBIx::Class::Migration::RunScript::Trait::Populate;
 
 use Moose::Role;
 use File::Spec::Functions 'catdir', 'catfile';
+use JSON::XS;
 
 requires 'schema';
 
 sub populate {
   my ($self, @sets) = @_;
+
+  my $fixtures_init_args =
+    JSON::XS->new->decode( $ENV{DBIC_MIGRATION_FIXTURES_INIT_ARGS} );
+  my $fixtures_obj =
+    $ENV{DBIC_MIGRATION_FIXTURES_CLASS}->new($fixtures_init_args);
+
   foreach my $set(@sets) {
-  $ENV{DBIC_MIGRATION_FIXTURES_OBJ}->populate({
+    $fixtures_obj->populate({
     no_deploy => 1,
     schema => $self->schema,
     directory => catdir($ENV{DBIC_MIGRATION_FIXTURE_DIR}, $set) });

--- a/t/migration-mysql.t
+++ b/t/migration-mysql.t
@@ -52,7 +52,7 @@ use DBIx::Class::Migration::RunScript;
 migrate {
   my $self = shift;
   if($self->set_has_fixtures('all_tables')) {
-    $self->populate('all_tables');
+    lives_ok { $self->populate('all_tables') } "->populate('all_tables')";
   } else {
     $self->schema
       ->resultset('Country')
@@ -63,7 +63,7 @@ migrate {
         ['fra'],
       ]);
 
-    $self->dump('all_tables');
+    lives_ok { $self->dump('all_tables') } "->dump('all_tables')";
     ok $self->set_has_fixtures('all_tables'),
       'Fixture Set exists!';
   }


### PR DESCRIPTION
Rationale: As of Perl v5.18.0, both keys and values stored in %ENV are stringified.
GH Issue: #59 

DCM used to pass DBIC::Fixtures obj via ENV to runscripts and this fails for Perl >= 5.18. This patch instead passes just the init args and the fixtures class via ENV and the fixtures object is constructed in the Dump and Populate traits.

All tests passing locally for 5.14.4, 5.20.2, 5.20.3 and 5.22.0