### PR TITLE
Typos/bad links - Correct spelling of "DBIx::Class::Migration"

### DIFF
--- a/lib/DBIx/Class/Migration/FAQ.pod
+++ b/lib/DBIx/Class/Migration/FAQ.pod
@@ -191,8 +191,8 @@ given version, manage fixtures, do some sane testing, etc.  Maybe you'll even
 be able to convince people to try out L<DBIx::Class>!
 
 By the way, if you wanted, you can always dump the generated version of your
-classes using C<make_schema> (see L<DBIx::Class::Migrations/make_schema> and
-L<DBIx::Class::Migrations::Script/make_schema>).
+classes using C<make_schema> (see L<DBIx::Class::Migration/make_schema> and
+L<DBIx::Class::Migration::Script/make_schema>).
 
 =head1 I am using MySQL and when the migration fails, it doesn't ROLLBACK
 

--- a/lib/DBIx/Class/Migration/Population.pm
+++ b/lib/DBIx/Class/Migration/Population.pm
@@ -134,9 +134,9 @@ Sometimes you just need to populate data for your scripts, such as during
 testing and you don't want to expose a full migrations interface and let
 someone accidently wipe your database with one command.  This utility is
 designed to assist.  It is basically a thin wrapper on L<DBIx::Class::Fixtures>
-that is just aware of L<DBIx::Class::Migrations> conventions.
+that is just aware of L<DBIx::Class::Migration> conventions.
 
-You create an instance of this similarly to L<DBIx::Class::Migrations>, except
+You create an instance of this similarly to L<DBIx::Class::Migration>, except
 you can't pass any arguments related to L<DBIx::Class::DeploymentHandler> since
 you don't have one :).  You can create it from an existing schema, or build it
 from a schema_class and schema_args, and optional set a target directory (or


### PR DESCRIPTION
This resolves https://github.com/jjn1056/DBIx-Class-Migration/issues/73
