### PR TITLE
Fix assumed version and fixture path if installing to_version

### DIFF
--- a/lib/DBIx/Class/Migration.pm
+++ b/lib/DBIx/Class/Migration.pm
@@ -369,11 +369,13 @@ sub _prepare_fixture_data_dir {
 
 sub build_dbic_fixtures_init_args {
   my $self = shift;
-  my $version = $self->dbic_dh->version_storage_is_installed ?
-    $self->dbic_dh->database_version : do {
+  my $dh = $self->dbic_dh;
+  my $version = $dh->version_storage_is_installed ?
+    $dh->database_version : do {
+      my $version = $dh->to_version || $dh->schema_version;
       print "Since this database is not versioned, we will assume version ";
-      print "${\$self->dbic_dh->schema_version}\n";
-      $self->dbic_dh->schema_version;
+      print "$version\n";
+      $version;
     };
 
   my $conf_dir = _prepare_fixture_conf_dir($self->target_dir, $version);

--- a/t/upgrade-downgrade-sqlite.t
+++ b/t/upgrade-downgrade-sqlite.t
@@ -231,6 +231,28 @@ CHECK_DOWNGRADE: {
 
 }
 
+TO_VERSION: {
+
+  ok(
+    my $migration = DBIx::Class::Migration->new(
+      schema_class=>'Local::v2::Schema',
+      schema_args => $schema_args,
+      dbic_dh_args=> {
+        to_version => 1,
+      },
+    ),
+    'created migration with to_version');
+
+  $migration->drop_tables;
+
+  use Capture::Tiny qw( capture );
+  my ($stdout, $stderr, $retval) = capture { $migration->install };
+
+  like $stdout, qr{assume version 1}, 'Assume version from to_version';
+  like $stdout, qr{1/conf}, 'Configuration files from to_version version';
+  is $migration->dbic_dh->database_version, 1, 'Installed specified version';
+}
+
 done_testing;
 
 END {


### PR DESCRIPTION
I bumped into a similar issue as that reported in #42 and while poking around in the code I found that the fixture path seems to not be determined from the version specified by `to_version`. When I changed this, my issue went away.

This patch includes these changes, which also correct the debug messages you get when installing using `--to_version`. It also includes tests for the debug messages and the versioned installation, which I don't think existed elsewhere.

The test does use Capture::Tiny, but this module is already listed in the MetaCPAN dependency graph, so I figured it was OK to use it.
