### PR TITLE
Filter out invalid and duplicate modules in DBIx::Class::Migration::RunScript::builder

### DIFF
--- a/lib/DBIx/Class/Migration/RunScript.pm
+++ b/lib/DBIx/Class/Migration/RunScript.pm
@@ -6,6 +6,7 @@ use Log::Any;
 use Carp 'croak';
 use DBIx::Class::Migration::Types -all;
 use Exporter qw(import);
+use List::Util qw(none);
 
 with 'MooX::Traits';
 
@@ -119,7 +120,8 @@ sub builder(&) {
     if(ref $plugins) {
       %args = (%args, %$plugins);
     } else {
-      push @traits, $plugins;
+      push @traits, $plugins
+        if (none { $_ eq $plugins } @traits) && $plugins !~ /__AND__|__WITH__/;
     }
   }
 


### PR DESCRIPTION
This fixes what I'm hoping is the root problem of #124.