### PR TITLE
Remove large amounts of warnings from normal use of `migrate`

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -52,6 +52,7 @@ Exporter = 5.57
 Test::Most = 0.34
 File::Spec::Functions = 0
 File::Path = 0
+Test::Warnings = 0
 Test::Requires = 0.10
 
 ; authordep Test::mysqld

--- a/lib/DBIx/Class/Migration/RunScript.pm
+++ b/lib/DBIx/Class/Migration/RunScript.pm
@@ -106,11 +106,27 @@ sub default_plugins {
 }
 
 sub used_plugins {
+  #allow the user to specify plugins for the migration by just
+  #use-ing them
+  #We find them by looking for packages loaded in %INC that have
+  #the key matching the namespace defined by $path
   my $path = 'DBIx/Class/Migration/RunScript/Trait/';
   my $match = "$path(.+).pm";
+
+  #however, there's one danger: if there's already been a
+  #migration object created, which will have MANY matches for
+  #$path in it, along with __AND and other things that
+  #Moox::Traits::Util names a package with dynamic roles, we
+  #shouldn't try to include that. Packages made that way get the
+  #same %INC value as MooX::Traits::Util, so let's save that.
   my $traits_path = $INC{'MooX/Traits/Util.pm'};
+
+  #so we get the list of packages loaded that match $path
   my @traits = grep { m[$path]x } keys %INC;
+  #filter out any that were made via MooX::Traits::Util, if it was
+  #loaded at all, yet
   @traits = grep { $INC{$_} ne $traits_path } @traits if $traits_path;
+  #and return the last part of the path, the name of the plugin
   return map { m[$match]x } @traits;
 }
 

--- a/lib/DBIx/Class/Migration/RunScript.pm
+++ b/lib/DBIx/Class/Migration/RunScript.pm
@@ -109,8 +109,9 @@ sub used_plugins {
   my $path = 'DBIx/Class/Migration/RunScript/Trait/';
   my $match = "$path(.+).pm";
   my $traits_path = $INC{'MooX/Traits/Util.pm'};
-  return map { m[$match]x }
-    grep { $INC{$_} ne $traits_path and m[$path]x } keys %INC;
+  my @traits = grep { m[$path]x } keys %INC;
+  @traits = grep { $INC{$_} ne $traits_path } @traits if $traits_path;
+  return map { m[$match]x } @traits;
 }
 
 sub builder(&) {

--- a/t/migrate_sugar.t
+++ b/t/migrate_sugar.t
@@ -2,6 +2,7 @@ use strict;
 use warnings;
 use lib 't/lib';
 use Test::Most;
+use Test::Warnings;
 use DBIx::Class::Migration;
 use DBIx::Class::Migration::RunScript;
 use File::Temp 'tempdir';
@@ -25,22 +26,6 @@ my $runs = sub {
   ok $runscript->schema->resultset('Artist'), 'got Artist RS';
 };
 
-subtest BASIC => sub {
-  my $run = DBIx::Class::Migration::RunScript->new_with_traits(
-    traits=>['SchemaLoader'], runs=>$runs);
-
-  $run->as_coderef->($migration->schema, [1,2]);
-};
-
-subtest SUGAR => sub {
-  my $code = builder {
-    'SchemaLoader',
-    $runs,
-  };
-  
-  $code->($migration->schema, [1,2]);
-};
-
 subtest SUGAR2 => sub {
   my $code = migrate {
     $runs->(shift)
@@ -48,12 +33,5 @@ subtest SUGAR2 => sub {
   $code->($migration->schema, [1,2]);
 };
 
-# second go so that %INC now contains RunScript with all traits to trigger bug
-subtest SUGAR3 => sub {
-  my $code = migrate {
-    $runs->(shift)
-  };
-  $code->($migration->schema, [1,2]);
-};
 
 done_testing;

--- a/t/migrate_sugar.t
+++ b/t/migrate_sugar.t
@@ -26,12 +26,12 @@ my $runs = sub {
   ok $runscript->schema->resultset('Artist'), 'got Artist RS';
 };
 
-subtest SUGAR2 => sub {
-  my $code = migrate {
-    $runs->(shift)
-  };
-  $code->($migration->schema, [1,2]);
+use DBIx::Class::Migration::RunScript::Trait::Populate;
+my $code = migrate {
+  $runs->(shift)
 };
+$code->($migration->schema, [1,2]);
+
 
 
 done_testing;


### PR DESCRIPTION
This is a pull request to fix #130 . So far I've added a test to replicate the issue, and a fix should be forthcoming rather soon.