### PR TITLE
Fix version numbers in ThirdMigration tutorial text

### DIFF
--- a/lib/DBIx/Class/Migration/Tutorial/ThirdMigration.pod
+++ b/lib/DBIx/Class/Migration/Tutorial/ThirdMigration.pod
@@ -385,8 +385,8 @@ you might which to 'clean' things up, with something like:
     Reading configurations from ...MusicBase/share/fixtures/2/conf
     Restored set all_tables to database
 
-As you might notice above, even though the schema is version 2, we installed
-fixtures from version one.  The tool will always try to match fixture populates
+As you might notice above, even though the schema is version 3, we installed
+fixtures from version 2.  The tool will always try to match fixture populates
 to the current database version.  And remember, if you don't tell C<populate>
 which fixture set to restore, it will always use the C<all_tables> set.
 


### PR DESCRIPTION
While reading through the `ThirdMigration` part of the tutorial, I noticed that the version numbers mentioned in the text didn't match what the actual schema and fixtures version numbers were from the code output.  This change fixes this issue.

This PR is submitted in the hope that it is useful. If you wish for any changes, please don't hesitate to contact me and I'll be more than happy to update and resubmit as necessary.